### PR TITLE
Add missing #include <unistd.h>

### DIFF
--- a/vtuner-simple.c
+++ b/vtuner-simple.c
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <time.h>
+#include <unistd.h>
 
 #define VTUNER_MAJOR        226
 #define VTUNER_GET_MESSAGE  _IOR(VTUNER_MAJOR, 1, struct vtuner_message *)


### PR DESCRIPTION
Fixes:

    vtuner-simple.c:51:24: warning: implicit declaration of function ‘read’ [-Wimplicit-function-declaration]
    vtuner-simple.c:52:19: warning: implicit declaration of function ‘write’ [-Wimplicit-function-declaration]
    vtuner-simple.c:53:13: warning: implicit declaration of function ‘usleep’ [-Wimplicit-function-declaration]
    vtuner-simple.c:60:9: warning: implicit declaration of function ‘lseek’ [-Wimplicit-function-declaration]